### PR TITLE
Improve authentication error handling

### DIFF
--- a/download-splunkbase.py
+++ b/download-splunkbase.py
@@ -89,12 +89,19 @@ def splunk_login(session, username, password):
     BASE_AUTH_URL = "https://login.splunk.com/api/v2/auth/okta-login"
     headers = {"accept": "*/*", "Content-Type": "application/json"}
 
-    csrf = (json.loads((session.get(CSRF_BASE_URL, headers=headers)).text))["_csrf"]
+    try:
+        csrf = (json.loads((session.get(CSRF_BASE_URL, headers=headers)).text))["_csrf"]
 
-    data = {"username": username, "password": password, "_csrf": csrf}
+        data = {"username": username, "password": password, "_csrf": csrf}
 
-    auth = session.post(BASE_AUTH_URL, json=data, headers=headers, allow_redirects=True)
-    return auth
+        auth = session.post(BASE_AUTH_URL, json=data, headers=headers, allow_redirects=True)
+        return auth
+    except json.decoder.JSONDecodeError:
+        print("Unable to authenticate - error", session.get(CSRF_BASE_URL, headers=headers).status_code)
+        exit(1)
+    except Exception as e:
+        print(f"Error occurred: {e}")
+        exit(1)
 
 
 def tgz_download(username, password, splunkbase_num, version):


### PR DESCRIPTION
Added a try-catch so when it fails, it's not just spitting out some stuff about not being able to parse JSON.

```
Traceback (most recent call last):
  File "/home/permanently/splunkbase-download/download-splunkbase.py", line 137, in <module>
    tgz_download(
  File "/home/permanently/splunkbase-download/download-splunkbase.py", line 102, in tgz_download
    auth = splunk_login(session, username, password)
  File "/home/permanently/splunkbase-download/download-splunkbase.py", line 92, in splunk_login
    csrf = (json.loads((session.get(CSRF_BASE_URL, headers=headers)).text))["_csrf"]
  File "/usr/lib/python3.10/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.10/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.10/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

Speaking of which, I've been getting a lot of 403s. Might be because I'm on workspace internet and VPNs, although you'd think with companies using Splunk this wouldn't be the case at all. Regardless, this change handles those errors a little bit better.